### PR TITLE
DO NOT MERGE: Downgrade safari-technology-preview to 70

### DIFF
--- a/Casks/affinity-photo-beta.rb
+++ b/Casks/affinity-photo-beta.rb
@@ -1,6 +1,6 @@
 cask 'affinity-photo-beta' do
-  version '1.7.0.103'
-  sha256 'c80feae19054b6e5f3e48513af75a055c5cc4264419aebadf2d2f418377be6ed'
+  version '1.7.0.104'
+  sha256 'b803adba9f473496235ebb88c2a7f9209fb2845f529e40811919675af11fffa1'
 
   # affinity-beta.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://affinity-beta.s3.amazonaws.com/download/Affinity%20Photo%20Customer%20Beta.dmg'

--- a/Casks/android-studio-preview.rb
+++ b/Casks/android-studio-preview.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-preview' do
-  version '3.4.0.4,183.5141831'
-  sha256 'a277ab848578d0121c73ad0d5c100dbfc802b4a80c5d40e67ed1fe23a94720b1'
+  version '3.4.0.5,183.5146016'
+  sha256 '838548a4d21dd023d8ef68304efd49556fb0243e45139dbcfd443619c793422a'
 
   # google.com/dl/android/studio was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
@@ -10,15 +10,17 @@ cask 'android-studio-preview' do
   app "Android Studio #{version.major_minor} Preview.app"
 
   zap trash: [
-               "~/Library/Application Support/AndroidStudioPreview#{version.major_minor}",
-               "~/Library/Caches/AndroidStudioPreview#{version.major_minor}",
-               "~/Library/Logs/AndroidStudioPreview#{version.major_minor}",
-               "~/Library/Preferences/AndroidStudioPreview#{version.major_minor}",
-               '~/Library/Preferences/com.google.android.studio.plist',
+               '~/Library/Android/sdk',
+               "~/Library/Application Support/AndroidStudio#{version.major_minor}",
+               "~/Library/Caches/AndroidStudio#{version.major_minor}",
+               "~/Library/Logs/AndroidStudio#{version.major_minor}",
+               "~/Library/Preferences/AndroidStudio#{version.major_minor}",
+               '~/Library/Preferences/com.android.Emulator.plist',
+               '~/Library/Saved Application State/com.google.android.studio.savedState',
+               '~/.android',
              ],
-      rmdir: '~/AndroidStudioProjects'
-
-  caveats do
-    depends_on_java
-  end
+      rmdir: [
+               '~/AndroidStudioProjects',
+               '~/Library/Android',
+             ]
 end

--- a/Casks/java-beta.rb
+++ b/Casks/java-beta.rb
@@ -1,6 +1,6 @@
 cask 'java-beta' do
-  version '12,22'
-  sha256 '577ce294a1297ee6316cfec5637dffcdda229d3c0f7c94562b5efffb7dfd421c'
+  version '12,23'
+  sha256 '724d3b9ec4e223134112d93b25469f037955a00cf3ffb1af08c0a2e486d6bb79'
 
   url "https://download.java.net/java/early_access/jdk#{version.major}/#{version.after_comma}/GPL/openjdk-#{version.before_comma}-ea+#{version.after_comma}_osx-x64_bin.tar.gz"
   name 'OpenJDK - Early Access'

--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.2.4.1413,243'
-  sha256 '695ecda10f1e426f8d0f16130aa5b0ddc53b5ee018b883e94b33c90b6d87aabb'
+  version '10.2.4.1420,244'
+  sha256 'ae498c9a24e8ce1d44f845e1472fc919777b05503f38aba881757c042ad7141d'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06'

--- a/Casks/qt-creator-dev.rb
+++ b/Casks/qt-creator-dev.rb
@@ -1,8 +1,8 @@
 cask 'qt-creator-dev' do
-  version '4.8.0-beta1'
-  sha256 'c90242f3314129cd2e1a145d4e4cc07d6d1b2488aafefbf7f16d90d7dff33c78'
+  version '4.8.0'
+  sha256 'dbbcefe1233cb29f0d20565273b6e5262e60190bcddcc55ed5be97ff57284b7a'
 
-  url "https://download.qt.io/development_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
+  url "https://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator Dev'
   homepage 'https://www1.qt.io/developers/'
 

--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask 'safari-technology-preview' do
-  version '71'
+  version '70'
 
   if MacOS.version <= :high_sierra
-    url 'https://secure-appldnld.apple.com/STP/041-25903-20181205-73BA2D1C-E44B-11E8-BBCA-D37951E18787/SafariTechnologyPreview.dmg'
-    sha256 'bd24eb188f68d591ea39a5cffdaf4ff55794d5fdc4eb18a42c3c7163a34310f8'
+    url 'https://secure-appldnld.apple.com/STP/041-22612-20181114-184D1786-AA54-11E8-82D8-98865F2D1BD8/SafariTechnologyPreview.dmg'
+    sha256 'd4f4ef261f871626b416074fe2b00d8ef59bf5656579f3aeed31d306bc679c12'
   else
-    url 'https://secure-appldnld.apple.com/STP/041-25905-20181205-73BA2D1C-E44B-11E8-BBCA-D37951E18787/SafariTechnologyPreview.dmg'
-    sha256 '0237a42a7591df239a5081fe6709583d70e3ec1f0f52e9023f648c6f2db677f7'
+    url 'https://secure-appldnld.apple.com/STP/041-22615-20181114-184D1786-AA54-11E8-82D8-98865F2D1BD8/SafariTechnologyPreview.dmg'
+    sha256 'd41f25daa02774e7f79ddc8f288df1782f3c208ef2bbbb7b618abf541dac1b9d'
   end
 
   name 'Safari Technology Preview'

--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask 'safari-technology-preview' do
-  version '70'
+  version '71'
 
   if MacOS.version <= :high_sierra
-    url 'https://secure-appldnld.apple.com/STP/041-22612-20181114-184D1786-AA54-11E8-82D8-98865F2D1BD8/SafariTechnologyPreview.dmg'
-    sha256 'd4f4ef261f871626b416074fe2b00d8ef59bf5656579f3aeed31d306bc679c12'
+    url 'https://secure-appldnld.apple.com/STP/041-25903-20181205-73BA2D1C-E44B-11E8-BBCA-D37951E18787/SafariTechnologyPreview.dmg'
+    sha256 'bd24eb188f68d591ea39a5cffdaf4ff55794d5fdc4eb18a42c3c7163a34310f8'
   else
-    url 'https://secure-appldnld.apple.com/STP/041-22615-20181114-184D1786-AA54-11E8-82D8-98865F2D1BD8/SafariTechnologyPreview.dmg'
-    sha256 'd41f25daa02774e7f79ddc8f288df1782f3c208ef2bbbb7b618abf541dac1b9d'
+    url 'https://secure-appldnld.apple.com/STP/041-25905-20181205-73BA2D1C-E44B-11E8-BBCA-D37951E18787/SafariTechnologyPreview.dmg'
+    sha256 '0237a42a7591df239a5081fe6709583d70e3ec1f0f52e9023f648c6f2db677f7'
   end
 
   name 'Safari Technology Preview'

--- a/Casks/toggl-beta.rb
+++ b/Casks/toggl-beta.rb
@@ -1,6 +1,6 @@
 cask 'toggl-beta' do
-  version '7.4.299'
-  sha256 '399a1b316f9be1f3e19222f687aad74d3d6252db600b5bf3d932073568fb81e7'
+  version '7.4.321'
+  sha256 'f8a0d404486cf95e61760a3d956df88a3599d12e194cb5de2ae3f0f87201b29a'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"

--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.30.0,85f805acf9436381b878cab5ab6c5146beec7893'
-  sha256 '7fa2d79d1241ae664dde1c028830b6f236b9832eb4b8c6ae81c0dbc60d997a12'
+  version '1.30.0,048fdbba9505f64f583e9687806582c519fbdb9d'
+  sha256 '218a66b6f17310876408dab56057dceeaefe1d2b1f937b228b9d70ec88353d94'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"

--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '2.2.1373.4'
-  sha256 'cedd1d50c41ed92ddaba0c3761c04dcc4bd045218bbf6dedd343e3794cd73ec8'
+  version '2.2.1388.6'
+  sha256 '0bf9a2cddc83c36b286eee444d15ac803cf242997a899c7567a66d27e76ee87f'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'

--- a/Casks/workflowy-beta.rb
+++ b/Casks/workflowy-beta.rb
@@ -1,6 +1,6 @@
 cask 'workflowy-beta' do
-  version '1.1.9-beta.1954'
-  sha256 '110c2480e4741b61ff09829a10b0f3c948f177b3f651115588ea05320f1aa23f'
+  version '1.1.10-beta.2044'
+  sha256 '56efa89ed98ed8a9a89877e1eb948bb85b96153aad5b4afabb977dd50babdbf3'
 
   # github.com/workflowy/desktop-beta was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop-beta/releases/download/v#{version}/WorkFlowy-Beta.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

----

Version as reported by safaridriver --version:
Included with Safari Technology Preview (Release 70, 13607.1.13)

Source: https://developer.apple.com/safari/download/
Build: https://dev.azure.com/foolip/safari-technology-preview-updater/_build/results?buildId=225&view=logs